### PR TITLE
Fixed failing tests

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -126,7 +126,7 @@ describe UsersController, :orm => :active_record do
       end
 
       it "should contain the specified attributes" do
-        response_body_json["user"].should have(1).key        
+        response_body_json["user"].should have(1).keys
         response_body_json["user"].should have_key("profile")
       end
 

--- a/spec/models/base/associations_spec.rb
+++ b/spec/models/base/associations_spec.rb
@@ -23,7 +23,7 @@ describe ActsAsApi::Base do
       end
 
       it "returns the correct number of fields" do
-        @response.should have(1).key
+        @response.should have(1).keys
       end
 
       it "returns all specified fields" do
@@ -58,7 +58,7 @@ describe ActsAsApi::Base do
         end
 
         it "returns the correct number of fields" do
-          @response.should have(1).key
+          @response.should have(1).keys
         end
 
         it "returns all specified fields" do
@@ -99,7 +99,7 @@ describe ActsAsApi::Base do
         end
 
         it "returns the correct number of fields" do
-          @response.should have(1).key
+          @response.should have(1).keys
         end
 
         it "returns all specified fields" do
@@ -193,7 +193,7 @@ describe ActsAsApi::Base do
       end
 
       it "returns the correct number of fields" do
-        @response.should have(1).key
+        @response.should have(1).keys
       end
 
       it "returns all specified fields" do
@@ -236,7 +236,7 @@ describe ActsAsApi::Base do
         end
 
         it "returns the correct number of fields" do
-          @response.should have(1).key
+          @response.should have(1).keys
         end
 
         it "returns all specified fields" do
@@ -268,7 +268,7 @@ describe ActsAsApi::Base do
         end
 
         it "returns the correct number of fields" do
-          @response.should have(1).key
+          @response.should have(1).keys
         end
 
         it "returns all specified fields" do

--- a/spec/models/base/methods_spec.rb
+++ b/spec/models/base/methods_spec.rb
@@ -18,7 +18,7 @@ describe ActsAsApi::Base do
     end
 
     it "returns the correct number of fields" do
-      @response.should have(1).key
+      @response.should have(1).keys
     end
 
     it "returns all specified fields by name" do

--- a/spec/models/base/renaming_spec.rb
+++ b/spec/models/base/renaming_spec.rb
@@ -23,7 +23,7 @@ describe ActsAsApi::Base do
       end
 
       it "returns the correct number of fields" do
-        @response.should have(1).key
+        @response.should have(1).keys
       end
 
       it "returns all specified fields" do
@@ -47,7 +47,7 @@ describe ActsAsApi::Base do
       end
 
       it "returns the correct number of fields" do
-        @response.should have(1).key
+        @response.should have(1).keys
       end
 
       it "returns all specified fields" do

--- a/spec/models/base/sub_nodes_spec.rb
+++ b/spec/models/base/sub_nodes_spec.rb
@@ -23,7 +23,7 @@ describe ActsAsApi::Base do
       end
 
       it "returns the correct number of fields" do
-        @response.should have(1).key
+        @response.should have(1).keys
       end
 
       it "returns all specified fields" do
@@ -54,7 +54,7 @@ describe ActsAsApi::Base do
       end
 
       it "returns the correct number of fields" do
-        @response.should have(1).key
+        @response.should have(1).keys
       end
 
       it "returns all specified fields" do
@@ -94,7 +94,7 @@ describe ActsAsApi::Base do
       end
 
       it "returns the correct number of fields" do
-        @response.should have(1).key
+        @response.should have(1).keys
       end
 
       it "returns all specified fields" do

--- a/spec/rails_app/app/models/user.rb
+++ b/spec/rails_app/app/models/user.rb
@@ -35,14 +35,14 @@ class User < ActiveRecord::Base
   
   api_accessible :calling_a_proc do |t|
     t.add Proc.new{|model| model.full_name.upcase  }, :as => :all_caps_name
-    t.add Proc.new{ Time.now.class.to_s  }, :as => :without_param
+    t.add Proc.new{|model| Time.now.class.to_s  }, :as => :without_param
   end  
   
   api_accessible :calling_a_lambda do |t|
     t.add lambda{|model| model.full_name.upcase  }, :as => :all_caps_name
-    t.add lambda{ Time.now.class.to_s  }, :as => :without_param
+    t.add lambda{|model| Time.now.class.to_s  }, :as => :without_param
   end
-  User.api_accessible :include_tasks do |t| 
+  api_accessible :include_tasks do |t| 
     t.add :tasks
   end
      
@@ -88,7 +88,7 @@ class User < ActiveRecord::Base
 
   api_accessible :if_returns_nil_proc do |t| 
     t.add :first_name
-    t.add :last_name, :if => lambda{ nil }
+    t.add :last_name, :if => lambda{|u| nil }
   end
   
   api_accessible :unless_under_thirty do |t| 
@@ -108,7 +108,7 @@ class User < ActiveRecord::Base
 
   api_accessible :unless_returns_nil_proc do |t| 
     t.add :first_name
-    t.add :last_name, :unless => lambda{ nil }
+    t.add :last_name, :unless => lambda{|u| nil }
   end  
 
   def over_thirty?


### PR DESCRIPTION
On ruby 1.9.2p136, with RSpec 2.5.0.

There were initially 25 failing tests, based on two sets of problems.

The first of these were `@response.should have(1).key`, which I had to append an "s" to. I don't like the plural, but it was the only way I got the specs to pass. It gave an "ArgumentError: wrong number of arguments (0 for 1)"

The second was related to procs/lambda, when no parameter was given in the User model. E.g. `:if => lambda{ nil }` should be `:if => lambda{|u| nil }`, as it's called with a parameter every time.
