### PR TITLE
Mongoid support

### DIFF
--- a/lib/acts_as_api.rb
+++ b/lib/acts_as_api.rb
@@ -23,9 +23,14 @@ module ActsAsApi
   autoload :Rendering,    "acts_as_api/rendering"    
 end
 
-# Attach ourselves to active record
+# Attach ourselves to ActiveRecord
 if defined?(ActiveRecord::Base)
   ActiveRecord::Base.extend ActsAsApi::Base
+end
+
+# Attach ourselves to Mongoid
+if defined?(Mongoid::Document)
+  Mongoid::Document.send :include, ActsAsApi::Mongoid  
 end
 
 # Attach ourselves to the action controller of rails

--- a/lib/acts_as_api/mongoid.rb
+++ b/lib/acts_as_api/mongoid.rb
@@ -1,0 +1,9 @@
+module ActsAsApi
+  module Mongoid
+    extend ActiveSupport::Concern
+
+    included do
+      extend ActsAsApi::Base
+    end
+  end
+end


### PR DESCRIPTION
Due to Mongoid's component architecture and that it doesn't use inheritance for its ActiveModel objects, we can't just extend Mongoid::Document with ActsAsApi::Base.

I'm not sure if you want to move this off to some adapter folder or the like, but this works for me.
