### PR TITLE
bug fix for rendering non as_api_response objects, such as error hashs

### DIFF
--- a/lib/acts_as_api/responder.rb
+++ b/lib/acts_as_api/responder.rb
@@ -34,7 +34,7 @@ module ActsAsApi
     # Overrides the base implementation of display, replacing it with
     # the render_for_api method whenever api_template is specified.
     def display(resource, given_options={})
-      if api_template.nil?
+      if api_template.nil? || !resource.respond_to?(:as_api_response)
         controller.render given_options.merge!(options).merge!(format => resource)
       else
         controller.render_for_api api_template, given_options.merge!(options).merge!(format => resource)


### PR DESCRIPTION
Hi,

Just a quick bug fix on the new responder stuff. When an object has errors it will try to render a the hash containing these errors and fail. This patch checks to see if the resource can handle an as_api_request call.

Sorry I did not have time to write some tests for this

Hope it helps

Cheers

Scott
