### PR TITLE
Model Callbacks Added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-script: "bundle exec rake spec"

--- a/acts_as_api.gemspec
+++ b/acts_as_api.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel','>= 3.0.0')
   s.add_dependency('activesupport','>= 3.0.0')
   s.add_dependency('rack','>= 1.1.0')
-    
+
   s.add_development_dependency('rails', ['>= 3.0.0'])
   s.add_development_dependency('mongoid', ['>= 2.0.0'])
-  
+
   s.rdoc_options  = ['--main', 'README.rdoc', '--charset=UTF-8']
   s.extra_rdoc_files = ['README.rdoc']
   

--- a/lib/acts_as_api/base.rb
+++ b/lib/acts_as_api/base.rb
@@ -58,10 +58,21 @@ module ActsAsApi
       # Will raise an exception if the passed api template is not defined for the model
       def as_api_response(api_template)
         api_attributes = self.class.api_accessible_attributes(api_template)
-        
         raise ActsAsApi::TemplateNotFoundError.new("acts_as_api template :#{api_template.to_s} was not found for model #{self.class}") if api_attributes.nil?
+          
+        before_api_response(api_template) if respond_to? :before_api_response
         
-        api_attributes.to_response_hash(self)
+        response_hash = if respond_to? :around_api_response
+          around_api_response api_template do
+            api_attributes.to_response_hash(self)
+          end
+        else
+          api_attributes.to_response_hash(self)
+        end
+
+        after_api_response(api_template) if respond_to? :after_api_response
+
+        response_hash
       end
 
     end

--- a/spec/models/active_record_spec.rb
+++ b/spec/models/active_record_spec.rb
@@ -23,6 +23,7 @@ describe ActiveRecord, :orm => "active_record" do
     it_supports "creating a sub hash in the api template"
     it_supports "trying to render an api template that is not defined"
     it_supports "untouched models" 
+    it_supports "defining a model callback"
   end
   
 end

--- a/spec/models/mongoid_spec.rb
+++ b/spec/models/mongoid_spec.rb
@@ -22,7 +22,8 @@ describe Mongoid, :orm => "mongoid" do
     it_supports "listing attributes in the api template"
     it_supports "creating a sub hash in the api template"
     it_supports "trying to render an api template that is not defined"
-    it_supports "untouched models" 
+    it_supports "untouched models"
+    it_supports "defining a model callback"
   end
   
 end

--- a/spec/models/vanilla_ruby_spec.rb
+++ b/spec/models/vanilla_ruby_spec.rb
@@ -25,6 +25,7 @@ describe Class, :orm => "vanilla" do
     it_supports "trying to render an api template that is not defined"
     # deactivated as acts_as_api won't get mixed into any class
     # it_supports "untouched models"
+    it_supports "defining a model callback"
   end
   
 end

--- a/spec/rails_app/app/models/mongo_user.rb
+++ b/spec/rails_app/app/models/mongo_user.rb
@@ -119,6 +119,30 @@ class MongoUser
     t.add :last_name, :unless => lambda{|u| nil }
   end  
 
+  def before_api_response(api_response)
+    @before_api_response_called = true
+  end
+  
+  def before_api_response_called?
+    !!@before_api_response_called
+  end
+  
+  def after_api_response(api_response)
+    @after_api_response_called = true
+  end
+  
+  def after_api_response_called?
+    !!@after_api_response_called
+  end
+  
+  def skip_api_response=(should_skip)
+    @skip_api_response = should_skip
+  end
+  
+  def around_api_response(api_response)
+    @skip_api_response ? { :skipped => true } : yield
+  end
+  
   def over_thirty?
     age > 30
   end

--- a/spec/rails_app/app/models/user.rb
+++ b/spec/rails_app/app/models/user.rb
@@ -111,6 +111,30 @@ class User < ActiveRecord::Base
     t.add :first_name
     t.add :last_name, :unless => lambda{|u| nil }
   end
+  
+  def before_api_response(api_response)
+    @before_api_response_called = true
+  end
+  
+  def before_api_response_called?
+    !!@before_api_response_called
+  end
+  
+  def after_api_response(api_response)
+    @after_api_response_called = true
+  end
+  
+  def after_api_response_called?
+    !!@after_api_response_called
+  end
+  
+  def skip_api_response=(should_skip)
+    @skip_api_response = should_skip
+  end
+  
+  def around_api_response(api_response)
+    @skip_api_response ? { :skipped => true } : yield
+  end
 
   def over_thirty?
     age > 30

--- a/spec/rails_app/app/models/vanilla_user.rb
+++ b/spec/rails_app/app/models/vanilla_user.rb
@@ -122,6 +122,30 @@ class VanillaUser
     t.add :last_name, :unless => lambda{|u| nil }
   end  
 
+  def before_api_response(api_response)
+    @before_api_response_called = true
+  end
+  
+  def before_api_response_called?
+    !!@before_api_response_called
+  end
+  
+  def after_api_response(api_response)
+    @after_api_response_called = true
+  end
+  
+  def after_api_response_called?
+    !!@after_api_response_called
+  end
+  
+  def skip_api_response=(should_skip)
+    @skip_api_response = should_skip
+  end
+  
+  def around_api_response(api_response)
+    @skip_api_response ? { :skipped => true } : yield
+  end
+  
   def over_thirty?
     age > 30
   end

--- a/spec/support/model_examples/callbacks.rb
+++ b/spec/support/model_examples/callbacks.rb
@@ -1,0 +1,38 @@
+shared_examples_for "defining a model callback" do
+
+  describe "for a" do
+    
+    describe "around_api_response" do
+      
+      it "skips rendering if not yielded" do
+        @luke.skip_api_response = true
+        @luke.as_api_response(:name_only).keys.should include(:skipped)
+      end
+      
+      it "renders if yielded" do
+        @luke.as_api_response(:name_only).keys.should_not include(:skipped)
+      end
+    
+    end
+    
+    describe "before_api_response" do 
+      
+      it "is called properly" do
+        @luke.as_api_response(:name_only)
+        @luke.before_api_response_called?.should eql(true)
+      end
+      
+    end
+    
+    describe "after_api_response" do 
+      
+      it "is called properly" do
+        @luke.as_api_response(:name_only)
+        @luke.after_api_response_called?.should eql(true)
+      end
+      
+    end
+    
+  end
+
+end


### PR DESCRIPTION
As discussed <a href="https://github.com/fabrik42/acts_as_api/issues/23">here</a>, I have added support for the `before_api_response`, `around_api_response`, and `after_api_response` calls. Tests were written, and `rake spec` passes.
