### PR TITLE
compatible with rails 3.1rc

### DIFF
--- a/lib/acts_as_api/config.rb
+++ b/lib/acts_as_api/config.rb
@@ -4,7 +4,7 @@ module ActsAsApi
     
     class << self
 
-      attr_accessor :accepted_api_formats, :dasherize_for, :include_root_in_json_collections, :add_root_node_for, :default_root, :allow_jsonp_callback, :add_http_status_to_jsonp_response
+      attr_writer :accepted_api_formats, :dasherize_for, :include_root_in_json_collections, :add_root_node_for, :default_root, :allow_jsonp_callback, :add_http_status_to_jsonp_response
       
       # The accepted response formats
       # Default is <tt>[:xml, :json]</tt>


### PR DESCRIPTION
ActiveSupport 3.1 removed attr_accessor_with_default, use ruby attr_accessor method instead. Not sure this will break test, since I can't run specs on Mac os 10.7 for now :(

update: use attr_writer to replace attr_accessor 
thanks fabrik42 for fixing this. :)
