### PR TITLE
Added support to prefix and/or postfix templates.

### DIFF
--- a/lib/acts_as_api/rendering.rb
+++ b/lib/acts_as_api/rendering.rb
@@ -8,7 +8,16 @@ module ActsAsApi
     # to simply generate API outputs.
     #
     # The default Rails serializers are used to serialize the data.
-    def render_for_api(api_template, render_options)
+    def render_for_api(api_template_or_options, render_options)
+      if api_template_or_options.is_a?(Hash)
+        api_template = []
+        api_template << api_template_or_options.delete(:prefix)
+        api_template << api_template_or_options.delete(:template)
+        api_template << api_template_or_options.delete(:postfix)
+        api_template = api_template.reject(&:blank?).join('_')
+      else
+        api_template = api_template_or_options
+      end
 
       # extract the api format and model
       api_format_options = {}

--- a/spec/models/mongoid_spec.rb
+++ b/spec/models/mongoid_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mongoid, :orm => "mongoid" do
+describe "Mongoid", :orm => "mongoid" do
   
   before(:each) do
     setup_mongoid_models

--- a/spec/rails_app/app/controllers/respond_with_users_controller.rb
+++ b/spec/rails_app/app/controllers/respond_with_users_controller.rb
@@ -38,6 +38,12 @@ class RespondWithUsersController < ApplicationController
     respond_with @user
   end
 
+  def show_prefix_postfix
+    @user = @user_model.find(params[:id])
+    # :root => :user is only used here because we need it for the node name of the MongoUser model
+    respond_with @user, :api_template => {:template => params[:api_template], :prefix => params[:api_prefix], :postfix => params[:api_postfix]}, :root => :user
+  end
+
   def create
     @user = @user_model.new(params[:user])
 

--- a/spec/rails_app/app/controllers/users_controller.rb
+++ b/spec/rails_app/app/controllers/users_controller.rb
@@ -56,4 +56,14 @@ class UsersController < ApplicationController
     end
   end
 
+  def show_prefix_postfix
+    @user = @user_model.find(params[:id])
+    template = {:template => params[:api_template], :prefix => params[:api_prefix], :postfix => params[:api_postfix]}
+    respond_to do |format|
+      # :root => :user is only used here because we need it for the node name of the MongoUser model
+      format.xml { render_for_api template, :xml => @user, :root => :user }
+      format.json { render_for_api template, :json => @user, :root => :user }
+    end
+  end
+
 end

--- a/spec/rails_app/app/models/mongo_user.rb
+++ b/spec/rails_app/app/models/mongo_user.rb
@@ -119,6 +119,25 @@ class MongoUser
     t.add :last_name, :unless => lambda{|u| nil }
   end  
 
+  api_accessible :with_prefix_name_only do |t|
+    t.add lambda{|model| 'true' }, :as => :prefix
+    t.add :first_name
+    t.add :last_name
+  end
+
+  api_accessible :name_only_with_postfix do |t|
+    t.add :first_name
+    t.add :last_name
+    t.add lambda{|model| 'true' }, :as => :postfix
+  end
+
+  api_accessible :with_prefix_name_only_with_postfix do |t|
+    t.add lambda{|model| 'true' }, :as => :prefix
+    t.add :first_name
+    t.add :last_name
+    t.add lambda{|model| 'true' }, :as => :postfix
+  end
+
   def before_api_response(api_response)
     @before_api_response_called = true
   end

--- a/spec/rails_app/app/models/user.rb
+++ b/spec/rails_app/app/models/user.rb
@@ -111,6 +111,25 @@ class User < ActiveRecord::Base
     t.add :first_name
     t.add :last_name, :unless => lambda{|u| nil }
   end
+
+  api_accessible :with_prefix_name_only do |t|
+    t.add lambda{|model| 'true' }, :as => :prefix
+    t.add :first_name
+    t.add :last_name
+  end
+
+  api_accessible :name_only_with_postfix do |t|
+    t.add :first_name
+    t.add :last_name
+    t.add lambda{|model| 'true' }, :as => :postfix
+  end
+
+  api_accessible :with_prefix_name_only_with_postfix do |t|
+    t.add lambda{|model| 'true' }, :as => :prefix
+    t.add :first_name
+    t.add :last_name
+    t.add lambda{|model| 'true' }, :as => :postfix
+  end
   
   def before_api_response(api_response)
     @before_api_response_called = true

--- a/spec/rails_app/app/models/vanilla_user.rb
+++ b/spec/rails_app/app/models/vanilla_user.rb
@@ -122,6 +122,25 @@ class VanillaUser
     t.add :last_name, :unless => lambda{|u| nil }
   end  
 
+  api_accessible :with_prefix_name_only do |t|
+    t.add lambda{|model| 'true' }, :as => :prefix
+    t.add :first_name
+    t.add :last_name
+  end
+
+  api_accessible :name_only_with_postfix do |t|
+    t.add :first_name
+    t.add :last_name
+    t.add lambda{|model| 'true' }, :as => :postfix
+  end
+
+  api_accessible :with_prefix_name_only_with_postfix do |t|
+    t.add lambda{|model| 'true' }, :as => :prefix
+    t.add :first_name
+    t.add :last_name
+    t.add lambda{|model| 'true' }, :as => :postfix
+  end
+
   def before_api_response(api_response)
     @before_api_response_called = true
   end

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -8,6 +8,7 @@ RailsApp::Application.routes.draw do
     member do
       get 'show_meta'
       get 'show_default'
+      get 'show_prefix_postfix'
     end
   end
 
@@ -19,6 +20,7 @@ RailsApp::Application.routes.draw do
     member do
       get 'show_meta'
       get 'show_default'
+      get 'show_prefix_postfix'
     end
   end
 

--- a/spec/support/controller_examples.rb
+++ b/spec/support/controller_examples.rb
@@ -385,4 +385,80 @@ shared_examples_for "a controller with ActsAsApi responses" do
     end
   end
 
+
+  describe 'api prefix' do
+
+    describe 'get single user' do
+
+      before(:each) do
+        get :show_prefix_postfix, :format => 'xml', :api_template => :name_only, :api_prefix => :with_prefix, :id => @luke.id, :orm => @orm_for_testing
+      end
+
+      it "should have a root node named user" do
+        response_body.should have_selector("user")
+      end
+
+      it "should contain the specified attributes" do
+        response_body.should have_selector("user > prefix")
+        response_body.should have_selector("user > first-name")
+        response_body.should have_selector("user > last-name")
+      end
+
+      it "should not contain the specified attributes" do
+        response_body.should_not have_selector("user > postfix")
+      end
+
+    end
+
+  end
+
+  describe 'api postfix' do
+
+    describe 'get single user' do
+
+      before(:each) do
+        get :show_prefix_postfix, :format => 'xml', :api_template => :name_only, :api_postfix => :with_postfix, :id => @luke.id, :orm => @orm_for_testing
+      end
+
+      it "should have a root node named user" do
+        response_body.should have_selector("user")
+      end
+
+      it "should contain the specified attributes" do
+        response_body.should have_selector("user > first-name")
+        response_body.should have_selector("user > last-name")
+        response_body.should have_selector("user > postfix")
+      end
+
+      it "should not contain the specified attributes" do
+        response_body.should_not have_selector("user > prefix")
+      end
+
+    end
+
+  end
+
+  describe 'api prefix and api postfix' do
+
+    describe 'get single user' do
+
+      before(:each) do
+        get :show_prefix_postfix, :format => 'xml', :api_template => :name_only, :api_prefix => :with_prefix, :api_postfix => :with_postfix, :id => @luke.id, :orm => @orm_for_testing
+      end
+
+      it "should have a root node named user" do
+        response_body.should have_selector("user")
+      end
+
+      it "should contain the specified attributes" do
+        response_body.should have_selector("user > prefix")
+        response_body.should have_selector("user > first-name")
+        response_body.should have_selector("user > last-name")
+        response_body.should have_selector("user > postfix")
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
This changes the render_for_api method instead of relying on the renderer in #38
