### PR TITLE
ActsAsApi::Config.add_http_status_to_jsonp_response always false

### DIFF
--- a/lib/acts_as_api/config.rb
+++ b/lib/acts_as_api/config.rb
@@ -49,7 +49,7 @@ module ActsAsApi
       # If true the jsonp function call will get the http status passed
       # as a second parameter
       def add_http_status_to_jsonp_response
-        @add_http_status_to_jsonp_response || true     
+        @add_http_status_to_jsonp_response.nil? ? true : @add_http_status_to_jsonp_response
       end
     end
     


### PR DESCRIPTION
in current code,

```
def add_http_status_to_jsonp_response
  @add_http_status_to_jsonp_response || true
end
```

this function returns true if `@add_http_status_to_jsonp_response` be false.

so, I wrote quick fix for around this issue.
