### PR TITLE
support for collection_root_override

### DIFF
--- a/lib/acts_as_api/config.rb
+++ b/lib/acts_as_api/config.rb
@@ -4,7 +4,7 @@ module ActsAsApi
     
     class << self
 
-      attr_writer :accepted_api_formats, :dasherize_for, :include_root_in_json_collections, :add_root_node_for, :default_root, :allow_jsonp_callback, :add_http_status_to_jsonp_response
+      attr_writer :accepted_api_formats, :dasherize_for, :include_root_in_json_collections, :add_root_node_for, :default_root, :allow_jsonp_callback, :add_http_status_to_jsonp_response, :collection_root_override
       
       # The accepted response formats
       # Default is <tt>[:xml, :json]</tt>
@@ -50,6 +50,12 @@ module ActsAsApi
       # as a second parameter
       def add_http_status_to_jsonp_response
         @add_http_status_to_jsonp_response.nil? ? true : @add_http_status_to_jsonp_response
+      end
+
+      # If set, the JSON root for collections will be set to the override
+      # instead of the pluralized model name.
+      def collection_root_override
+        @collection_root_override || nil
       end
     end
     

--- a/lib/acts_as_api/rendering.rb
+++ b/lib/acts_as_api/rendering.rb
@@ -57,6 +57,10 @@ module ActsAsApi
 
       if api_model.is_a?(Array) || (defined?(ActiveRecord) && api_model.is_a?(ActiveRecord::Relation))
         api_root_name = api_root_name.pluralize
+
+        if ActsAsApi::Config.collection_root_override
+          api_root_name = ActsAsApi::Config.collection_root_override
+        end
       end
 
       api_root_name = api_root_name.dasherize if ActsAsApi::Config.dasherize_for.include? api_format.to_sym
@@ -77,7 +81,7 @@ module ActsAsApi
       end
 
       api_response = meta_hash.merge api_response if meta_hash
-      
+
       if ActsAsApi::Config.allow_jsonp_callback && params[:callback]
         output_params[:callback] = params[:callback]
         api_format = :acts_as_api_jsonp if ActsAsApi::Config.add_http_status_to_jsonp_response


### PR DESCRIPTION
This patch adds support for (optional) overriding root json key for collections.

This allows us to keep the legacy acts_as_api behavior, back at the time where all collections came with a "records" root.
