### PR TITLE
Fix response for array of plain objects

### DIFF
--- a/lib/acts_as_api/rendering.rb
+++ b/lib/acts_as_api/rendering.rb
@@ -47,12 +47,13 @@ module ActsAsApi
         api_root_name = api_model.collection_name
       elsif api_model.is_a?(Array) && !api_model.empty? && api_model.first.class.respond_to?(:model_name)
         api_root_name = api_model.first.class.model_name
+      elsif api_model.is_a?(Array) && !api_model.empty? && api_model.first.respond_to?(:model_name)
+        api_root_name = api_model.first.model_name
       elsif api_model.respond_to?(:model_name)
         api_root_name = api_model.model_name        
       else
         api_root_name = ActsAsApi::Config.default_root.to_s
       end
-
       api_root_name = api_root_name.to_s.underscore.tr('/', '_')
 
       if api_model.is_a?(Array) || (defined?(ActiveRecord) && api_model.is_a?(ActiveRecord::Relation))

--- a/spec/controllers/plain_objects_controller_spec.rb
+++ b/spec/controllers/plain_objects_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe SharedEngine::PlainObjectsController do
+  include ApiTestHelpers
+
+  before(:each) do
+    class SharedEngine::PlainObjectsController
+      include SimpleFixtures
+    end
+  end
+
+  describe 'get all users as a an array of plain objects, autodetecting the root node name' do
+
+    before(:each) do
+      get :index, :format => 'json', :api_template => :name_only
+    end
+
+    it "should have a root node named users" do
+      response_body_json.should have_key("plain_objects")
+    end
+
+    it "should contain all users" do
+      response_body_json["plain_objects"].should be_a(Array)
+    end
+
+    it "should contain the specified attributes" do
+      response_body_json["plain_objects"].first.should have_key("first_name")
+      response_body_json["plain_objects"].first.should have_key("last_name")
+    end
+
+    it "should contain the specified values" do
+      response_body_json["plain_objects"].first["first_name"].should eql("Han")
+      response_body_json["plain_objects"].first["last_name"].should eql("Solo")
+    end
+  end
+end

--- a/spec/shared_engine/app/controllers/shared_engine/plain_objects_controller.rb
+++ b/spec/shared_engine/app/controllers/shared_engine/plain_objects_controller.rb
@@ -1,0 +1,14 @@
+module SharedEngine
+  class PlainObjectsController < SharedEngine::ApplicationController
+    before_filter :setup_objects
+
+    def index
+      @users = [@han, @luke, @leia]
+
+      respond_to do |format|
+        format.xml  { render_for_api params[:api_template].to_sym, :xml => @users }
+        format.json { render_for_api params[:api_template].to_sym, :json => @users }
+      end
+    end
+  end
+end

--- a/spec/shared_engine/app/models/plain_object.rb
+++ b/spec/shared_engine/app/models/plain_object.rb
@@ -1,0 +1,17 @@
+class PlainObject < Struct.new(:first_name, :last_name, :age, :active)
+  extend ActsAsApi::Base
+
+  def initialize(opts)
+    opts.each do |k, v|
+      send("#{k}=", v)
+    end
+  end
+
+  def model_name
+    'plain_object'
+  end
+
+  acts_as_api
+
+  include SharedEngine::UserTemplate
+end

--- a/spec/shared_engine/config/routes.rb
+++ b/spec/shared_engine/config/routes.rb
@@ -23,4 +23,6 @@ SharedEngine::Engine.routes.draw do
       get 'show_prefix_postfix'
     end
   end
+
+  resources :plain_objects
 end

--- a/spec/support/simple_fixtures.rb
+++ b/spec/support/simple_fixtures.rb
@@ -21,6 +21,12 @@ module SimpleFixtures
     User.delete_all
   end
 
+  def setup_objects
+    @luke = PlainObject.new({ :first_name => 'Luke',      :last_name => 'Skywalker', :age => 25, :active => true  })
+    @han  = PlainObject.new({ :first_name => 'Han',       :last_name => 'Solo',      :age => 35, :active => true  })
+    @leia = PlainObject.new({ :first_name => 'Princess',  :last_name => 'Leia',      :age => 25, :active => false })
+  end
+
   # def setup_roflscale_models
   #   @orm_for_testing  = :vanilla
   #   @user_model       = VanillaUser


### PR DESCRIPTION
For an array of plain objects it won't create the choosen root key in the json.

For example:

```
class User 
  def model_name
    'user'
  end
end
@user = User.new(first_name: 'Luke', last_name: 'Skywalker')
render_for_api :public, :json => [@user]
```

Previous output:
{"records":[{"record":{"first_name":"Luke","last_name":"Skywalker"}}]}

New output:
{"users":[{"user":{"first_name":"Luke","last_name":"Skywalker"}}]}
