### PR TITLE
Refactoring: responder implementation has been moved to a nested module.

### DIFF
--- a/lib/acts_as_api/responder.rb
+++ b/lib/acts_as_api/responder.rb
@@ -20,26 +20,20 @@ module ActsAsApi
   # The `:api_template` parameter is required so the responder knows which api template it should render.
 
   class Responder < ActionController::Responder
+    module Module
+      # Overrides the base implementation of display, replacing it with
+      # the render_for_api method whenever api_template is specified.
+      def display(resource, given_options={})
+        api_template = options[:api_template]
 
-    # Should be specified as an option to the `respond_with` call
-    attr_reader :api_template
-
-    # Grabs the required :api_template parameter, then hands control back to
-    # the base ActionController::Responder initializer.
-    def initialize(controller, resources, options={})
-      @api_template = options.delete(:api_template)
-      super(controller, resources, options)
-    end
-
-    # Overrides the base implementation of display, replacing it with
-    # the render_for_api method whenever api_template is specified.
-    def display(resource, given_options={})
-      if api_template.nil? || !resource.respond_to?(:as_api_response)
-        controller.render given_options.merge!(options).merge!(format => resource)
-      else
-        controller.render_for_api api_template, given_options.merge!(options).merge!(format => resource)
+        if api_template.nil? || !resource.respond_to?(:as_api_response)
+          controller.render given_options.merge!(options).merge!(format => resource)
+        else
+          controller.render_for_api api_template, given_options.merge!(options).merge!(format => resource)
+        end
       end
     end
 
+    include Module
   end
 end


### PR DESCRIPTION
That makes it friendly to another useful 'responders' gem, allowing to combine responders:

```
responders ActsAsApi::Responder::Module, Responders::Pagination
```

The change is backwards-compatible, so you still can use original way of changing responder using

```
self.responder = ActsAsApi::Responder
```

No new tests, as no new functionality was added.
