### PR TITLE
Update rails_renderer.rb

### DIFF
--- a/lib/acts_as_api/rails_renderer.rb
+++ b/lib/acts_as_api/rails_renderer.rb
@@ -8,7 +8,7 @@ module ActsAsApi
       ActionController.add_renderer :acts_as_api_jsonp do |json, options|
         json = ActiveSupport::JSON.encode(json) unless json.respond_to?(:to_str)
         json = "#{options[:callback]}(#{json}, #{response.status})" unless options[:callback].blank?
-        self.content_type ||= Mime::JSON
+        self.content_type ||= options[:callback].blank ? Mime::JSON : Mime::JS 
         self.response_body = json
       end
     end


### PR DESCRIPTION
The content-type of the response for a JSONP request should be "text/javascript" (e.g., see: http://stackoverflow.com/a/111319). Otherwise, if the browser has enabled strict MIME type checking, it will NOT execute the response and thus the request will fail (e.g., see: http://webmasters.stackexchange.com/questions/50006/chrome-refused-to-execute-this-javascript-file).

p.s.: I'm not really familiar with rails, so please check syntax correctness before.