### PR TITLE
support for ActionController::API

### DIFF
--- a/lib/acts_as_api.rb
+++ b/lib/acts_as_api.rb
@@ -53,8 +53,9 @@ if defined?(Mongoid::Document)
   Mongoid::Document.send :include, ActsAsApi::Adapters::Mongoid
 end
 
-# Attach ourselves to the action controller of Rails
-if defined?(ActionController::Base)
-  ActionController::Base.send :include, ActsAsApi::Rendering
+# Attach ourselves to the controller classes (Base and API) of Rails
+if defined?(ActionController::Base) || defined?(ActionController::API)
+  ActionController::Base.send(:include, ActsAsApi::Rendering) if defined?(ActionController::Base)
+  ActionController::API.send(:include, ActsAsApi::Rendering) if defined?(ActionController::API)
   ActsAsApi::RailsRenderer.setup
 end


### PR DESCRIPTION
Hi,
I came across an issue when wanting to use acts_as_api in a Rails api only mode application. In api mode all controllers inherit from ActionController::API, but the rendering method was only included in ActionController::Base. So here is my fix for this issue.