### PR TITLE
Remove Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-sudo: false
-script: bundle exec rake spec:all
-services:
-  - mongodb
-rvm:
-  - 2.6.6

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# acts_as_api ![acts_as_api on travis ci](https://secure.travis-ci.org/fabrik42/acts_as_api.png?branch=master)
-
 acts_as_api makes creating XML/JSON responses in Rails 3, 4, 5 and 6 easy and fun.
 
 It provides a simple interface to determine the representation of your model data, that should be rendered in your API responses.


### PR DESCRIPTION
After the integration of GH actions for running the test suite, we can now remove the Travis CI integration.