### PR TITLE
Use #media_type instead of #content_type to fix deprecation warning

### DIFF
--- a/spec/support/controller_examples.rb
+++ b/spec/support/controller_examples.rb
@@ -257,7 +257,7 @@ shared_examples_for 'a controller with ActsAsApi responses' do
         end
 
         it 'should set the content type to JavaScript' do
-          expect(response.content_type).to eq(Mime[:js])
+          expect(response.media_type).to eq(Mime[:js])
         end
       end
     end


### PR DESCRIPTION
see https://github.com/rails/rails/pull/36854

and https://guides.rubyonrails.org/6_0_release_notes.html#action-pack-notable-changes